### PR TITLE
Fix NullPointerException caused by s3:TestEvent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <groupId>org.sherzberg.graylog.plugins</groupId>
     <artifactId>graylog-plugin-s3</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.5.0</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>

--- a/src/main/java/org/sherzberg/graylog/aws/inputs/s3/S3Subscriber.java
+++ b/src/main/java/org/sherzberg/graylog/aws/inputs/s3/S3Subscriber.java
@@ -113,6 +113,7 @@ public class S3Subscriber extends Thread {
 
                             String message;
                             while ((message = reader.readLine()) != null) {
+                                LOG.debug("S3 Event message : {}", message);
                                 S3Record s3Record = new S3Record();
                                 s3Record.s3Bucket = n.getS3Bucket();
                                 s3Record.s3ObjectKey = n.getS3ObjectKey();

--- a/src/main/java/org/sherzberg/graylog/aws/inputs/s3/notifications/S3SNSNotification.java
+++ b/src/main/java/org/sherzberg/graylog/aws/inputs/s3/notifications/S3SNSNotification.java
@@ -23,4 +23,12 @@ public class S3SNSNotification {
         return s3ObjectKey;
     }
 
+    @Override
+    public String toString() {
+        return "S3SNSNotification{" +
+                "receiptHandle='" + receiptHandle + '\'' +
+                ", s3Bucket='" + s3Bucket + '\'' +
+                ", s3ObjectKey='" + s3ObjectKey + '\'' +
+                '}';
+    }
 }


### PR DESCRIPTION
S3 sends TestEvents and there is no record in this event so it causes NullPointerException and pause on input. Handling TestEvents fixed the issue.
Tested with Graylog 4.0.11. Importing AWS ALB logs, from S3 over SNS over SQS is working now.